### PR TITLE
Add new feature:  Number formatting function

### DIFF
--- a/script.js
+++ b/script.js
@@ -49,3 +49,13 @@ form.addEventListener('keypress', function (e) {
     equal.click();
   }
 });
+
+// Function to format numbers with a digit threshold
+function formatted(number, digitThreshold = 10) {
+  const digitCount = `${number}`.replace(/^0+|\.+/g, '').length;
+  if (digitCount > digitThreshold) {
+    return number.toExponential(7).replace('+', '');
+  } else {
+    return number.toLocaleString();
+  }
+}


### PR DESCRIPTION
This function takes a number and a digit threshold as arguments and returns a formatted string representation of the number. If the number has more digits than the threshold, it uses exponential notation (e.g., '1.234e+5'), and if the number has fewer digits, it uses standard number formatting with commas for thousands separators (e.g., '1,234'). This provides a flexible way to format numbers based on their digit count.